### PR TITLE
added JsonNull node for null values

### DIFF
--- a/src/main/java/com/fasterxml/jackson/jr/tree/JacksonJrSimpleTreeCodec.java
+++ b/src/main/java/com/fasterxml/jackson/jr/tree/JacksonJrSimpleTreeCodec.java
@@ -56,7 +56,7 @@ public class JacksonJrSimpleTreeCodec extends TreeCodec
             }
             node = new JsonObject(values);
         } else if (currentToken == JsonToken.VALUE_NULL) {
-            node = null;
+            node = JsonNull.instance;
         } else {
             throw new UnsupportedOperationException("Unsupported token " + currentToken);
         }
@@ -69,7 +69,7 @@ public class JacksonJrSimpleTreeCodec extends TreeCodec
     }
 
     private void writeTreeInternal(JsonGenerator g, final TreeNode treeNode) throws IOException {
-        if (treeNode == null) {
+        if (treeNode instanceof JsonNull) {
             g.writeNull();
         } else if (treeNode instanceof JsonBoolean) {
             g.writeBoolean(treeNode == JsonBoolean.TRUE);
@@ -138,6 +138,10 @@ public class JacksonJrSimpleTreeCodec extends TreeCodec
 
     public TreeNode missingNode() {
         return JsonMissing.instance;
+    }
+
+    public TreeNode nullNode() {
+        return JsonNull.instance;
     }
 
     /*

--- a/src/main/java/com/fasterxml/jackson/jr/tree/JacksonJrValue.java
+++ b/src/main/java/com/fasterxml/jackson/jr/tree/JacksonJrValue.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.jr.tree.util.TreeTraversingParser;
 public abstract class JacksonJrValue implements TreeNode
 {
     protected static final JacksonJrValue MISSING = JsonMissing.instance();
+    protected static final JacksonJrValue NULL = JsonNull.instance();
 
     @Override
     public JsonParser.NumberType numberType() {

--- a/src/main/java/com/fasterxml/jackson/jr/tree/JsonNull.java
+++ b/src/main/java/com/fasterxml/jackson/jr/tree/JsonNull.java
@@ -1,0 +1,82 @@
+package com.fasterxml.jackson.jr.tree;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TreeNode;
+
+/**
+ * Null node for null fields instead of `real` null value
+ */
+public class JsonNull extends JacksonJrValue {
+    final static JsonNull instance = new JsonNull();
+
+    public final static JsonNull instance() {
+        return instance;
+    }
+
+    @Override
+    public JsonToken asToken() {
+        return JsonToken.VALUE_NULL;
+    }
+
+    @Override
+    public boolean isValueNode() {
+        return true;
+    }
+
+    @Override
+    public boolean isContainerNode() {
+        return false;
+    }
+
+    @Override
+    public boolean isMissingNode() {
+        return false;
+    }
+
+    @Override
+    protected JacksonJrValue _at(JsonPointer ptr) {
+        return this;
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public TreeNode get(String s) {
+        return null;
+    }
+
+    @Override
+    public TreeNode get(int i) {
+        return null;
+    }
+
+    @Override
+    public TreeNode path(String s) {
+        return NULL;
+    }
+
+    @Override
+    public TreeNode path(int i) {
+        return NULL;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o == this);
+    }
+
+    @Override
+    public String toString() {
+        // toString() should never return null
+        return "null";
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+}

--- a/src/test/java/com/fasterxml/jackson/jr/tree/SimpleReadTest.java
+++ b/src/test/java/com/fasterxml/jackson/jr/tree/SimpleReadTest.java
@@ -29,10 +29,10 @@ public class SimpleReadTest extends TestBase
 
     public void testSimpleMap() throws Exception
     {
-        final String INPUT = "{\"a\":1,\"b\":true,\"c\":3}";
+        final String INPUT = "{\"a\":1,\"b\":true,\"c\":3,\"d\":null}";
         TreeNode node = TREE_CODEC.readTree(_factory.createParser(INPUT));
         assertTrue(node instanceof JsonObject);
-        assertEquals(3, node.size());
+        assertEquals(4, node.size());
         // actually, verify with write...
         final StringWriter writer = new StringWriter();
         final JsonGenerator g = _factory.createGenerator(writer);
@@ -43,10 +43,10 @@ public class SimpleReadTest extends TestBase
 
     public void testSimpleMixed() throws Exception
     {
-        final String INPUT = "{\"a\":[1,2,{\"b\":true},3],\"c\":3}";
+        final String INPUT = "{\"a\":[1,2,{\"b\":true},3],\"c\":3,\"d\":null}";
         TreeNode node = TREE_CODEC.readTree(_factory.createParser(INPUT));
         assertTrue(node instanceof JsonObject);
-        assertEquals(2, node.size());
+        assertEquals(3, node.size());
         TreeNode list = node.get("a");
         assertTrue(list instanceof JsonArray);
 

--- a/src/test/java/com/fasterxml/jackson/jr/tree/SimpleTraverseTest.java
+++ b/src/test/java/com/fasterxml/jackson/jr/tree/SimpleTraverseTest.java
@@ -9,7 +9,7 @@ public class SimpleTraverseTest extends TestBase
 
     public void testSimpleObject() throws Exception
     {
-        final String INPUT = "{\"a\":[1,2,{\"b\":true},3],\"c\":-2}";
+        final String INPUT = "{\"a\":[1,2,{\"b\":true},3],\"c\":-2,\"d\":null}";
         TreeNode node = TREE_CODEC.readTree(_factory.createParser(INPUT));
         JsonParser p = node.traverse();
 
@@ -38,6 +38,10 @@ public class SimpleTraverseTest extends TestBase
         assertEquals("c", p.getCurrentName());
         assertToken(JsonToken.VALUE_NUMBER_INT, p.nextToken());
         assertEquals(-2, p.getIntValue());
+
+        assertToken(JsonToken.FIELD_NAME, p.nextToken());
+        assertEquals("d", p.getCurrentName());
+        assertToken(JsonToken.VALUE_NULL, p.nextToken());
 
         assertToken(JsonToken.END_OBJECT, p.nextToken());
 


### PR DESCRIPTION
When a json field is `null`, NodeCursor throws `NullPointerException` while traversing.

````
java.lang.NullPointerException: Attempt to invoke virtual method 'com.fasterxml.jackson.core.JsonToken com.fasterxml.jackson.jr.tree.JacksonJrValue.asToken()' on a null object reference
    at com.fasterxml.jackson.jr.tree.util.NodeCursor$ObjectCursor.nextToken(NodeCursor.java:224)
    at com.fasterxml.jackson.jr.tree.util.TreeTraversingParser.nextToken(TreeTraversingParser.java:155)
````

This solution adds `JsonNull` node to handle null values. In my opinion this works better than returning _real_ null value because when calling `TreeNode.get("name")` on a existing but null field, we can easily know this field is null rather than missing.